### PR TITLE
docs: Add mention of MacOS keybinding for pretty-printing

### DIFF
--- a/client/src_editor/Editor_Introduction.re
+++ b/client/src_editor/Editor_Introduction.re
@@ -32,7 +32,7 @@ let a: string = 1;|};
 
 let text7 = {|## Pretty print code
 
-Press Ctrl+Shift+I to pretty print Reason code. Try me!
+Press Ctrl+Shift+I (or Cmd+Shift+I on MacOS) to pretty print Reason code. Try me!
 
 **Note:** This feature is currently unavailable in Ocaml sketches |};
 


### PR DESCRIPTION
Add mention of MacOS keybinding for pretty-printing to the editor introduction.